### PR TITLE
Use Authors/Titles with UNIX line endings

### DIFF
--- a/src/js/woodhouse.coffee
+++ b/src/js/woodhouse.coffee
@@ -179,10 +179,10 @@ search_for_hash = ->
 $(document).ready ->
   console.log('ready')
 
-  Papa.parse("#{window.location.href.split("#")[0]}data/riddle-arnold_for_web.csv",
+  Papa.parse("#{window.location.href.split("#")[0]}data/riddle-arnold_for_web_authors_titles.csv",
     {
       download: true,
-      newline: "\r\n",
+      newline: "\n",
       worker: true,
       complete: (results) ->
         console.log("dictionary parsing complete")


### PR DESCRIPTION
@helmadik messaged me saying there were some issues with using their updated copy of the CSV. After looking into it, it seems like it's just that `data/riddle-arnold_for_web_authors_titles.csv` uses UNIX line endings (`\n`), while `data/riddle-arnold_for_web.csv` uses DOS line endings (`\r\n`). Since it's a parser option, it's easy enough to flip it there, but if you'd prefer I can make a different PR that does this by flipping the line endings for `data/riddle-arnold_for_web_authors_titles.csv` to DOS.

This is also why it took so much longer to do a parse with the updated file—the parser never saw a "new line", so it was trying to load everything into one giant record.